### PR TITLE
Change color schema on critical battery level

### DIFF
--- a/src/c/main.c
+++ b/src/c/main.c
@@ -1242,12 +1242,20 @@ static void handle_battery(BatteryChargeState charge_state) {
           textcolor_bat_uint8 = 0b11111111;
           bkgrcolor_bat_uint8 = variable_color;
         }
-    //On all Profiles, make battery white on red if <= 20%:
+        
+  //On all Profiles (except 0 and 1), make battery white on red if <= 20%:
     if (actual_battery_percent <= 20){
-      textcolor_bat_uint8 = 0b11111111;
-      bkgrcolor_bat_uint8 = variable_color;
+      if (ColorProfile == 0) {
+        textcolor_bat_uint8 = 0b11000000; //black
+        bkgrcolor_bat_uint8 = 0b11111111; //white
+      } else if (ColorProfile == 1) {
+        textcolor_bat_uint8 = 0b11111111; //white
+        bkgrcolor_bat_uint8 = 0b11000000; //black
+      } else {
+        textcolor_bat_uint8 = 0b11111111; //white
+        bkgrcolor_bat_uint8 = variable_color;
+      }
     }
-  
   
   
     GlobalInverterColor = textcolor_bat_uint8 & 0b00111111;


### PR DESCRIPTION
Change the behavior on pebble 2 with black white display: Now the
colors will be inverted when battery level is <= 20%.