### PR TITLE
Add Timeline Quick View support and fix build with current SDK

### DIFF
--- a/src/c/inc_background_layer_update_p_ps_pt_pts.h
+++ b/src/c/inc_background_layer_update_p_ps_pt_pts.h
@@ -17,7 +17,7 @@
   graphics_draw_line(ctx, GPoint( 85,  17), GPoint( 85,  68));
   graphics_draw_line(ctx, GPoint(  0,  50), GPoint( 84,  50));
   graphics_draw_line(ctx, GPoint(  0,  69), GPoint(168,  69));
-  graphics_draw_line(ctx, GPoint(  0,  90), GPoint(168,  90));
+  graphics_draw_line(ctx, GPoint(  0, TIME_POS()-4), GPoint(168,  90));
   graphics_draw_line(ctx, GPoint(  0, 154), GPoint(168, 154));
   
   #ifndef PBL_PLATFORM_APLITE
@@ -70,8 +70,8 @@
   //draw dots of time:
   graphics_context_set_fill_color(ctx, textcolor_clock);
   graphics_context_set_stroke_color(ctx, textcolor_clock);
-  graphics_fill_rect(ctx, GRect(69, 102, 7, 7), 0, 0);
-  graphics_fill_rect(ctx, GRect(69, 124, 7, 7), 0, 0);
+  graphics_fill_rect(ctx, GRect(69, TIME_POS()+6, 7, 7), 0, 0);
+  graphics_fill_rect(ctx, GRect(69, TIME_POS()+32, 7, 7), 0, 0);
   
   //draw arrows of sun rise/set:
   graphics_context_set_fill_color(ctx, GColorClear);

--- a/src/c/inc_main_load_p_ps_pt_pts.h
+++ b/src/c/inc_main_load_p_ps_pt_pts.h
@@ -1,19 +1,24 @@
+#ifndef PBL_PLATFORM_APLITE
+  time_pos_tiny = 72;
+  time_pos_normal = 94;
+  update_time_pos();
+#endif
 
   background_paint_layer = layer_create(GRect(0, 0, 144, 168));
   layer_set_update_proc(background_paint_layer, layer_update_callback_background);
   layer_add_child(main_window_layer, background_paint_layer);
   
-  s_image_layer_hour_1 = layer_create(GRect(4, 94, 26, 41));
+  s_image_layer_hour_1 = layer_create(GRect(4, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_hour_1, layer_update_callback_hour_1);
   layer_add_child(main_window_layer, s_image_layer_hour_1);
-  s_image_layer_hour_2 = layer_create(GRect(37, 94, 26, 41));
+  s_image_layer_hour_2 = layer_create(GRect(37, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_hour_2, layer_update_callback_hour_2);
   layer_add_child(main_window_layer, s_image_layer_hour_2);
   
-  s_image_layer_minute_1 = layer_create(GRect(80, 94, 26, 41));
+  s_image_layer_minute_1 = layer_create(GRect(80, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_minute_1, layer_update_callback_minute_1);
   layer_add_child(main_window_layer, s_image_layer_minute_1);
-  s_image_layer_minute_2 = layer_create(GRect(111, 94, 26, 41));
+  s_image_layer_minute_2 = layer_create(GRect(111, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_minute_2, layer_update_callback_minute_2);
   layer_add_child(main_window_layer, s_image_layer_minute_2);
   
@@ -82,6 +87,9 @@
   text_layer_set_font(Date_Layer, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
   text_layer_set_text_alignment(Date_Layer, GTextAlignmentCenter);
   layer_add_child(main_window_layer, text_layer_get_layer(Date_Layer));
+  #ifndef PBL_PLATFORM_APLITE
+    layer_set_hidden(text_layer_get_layer(Date_Layer), is_tiny_view);
+  #endif
   
   // Calendar Week
   cwLayer = text_layer_create(GRect(72, 135, 64, 20)); //64 = label_width = 144-72-2*4 = display_width - display_width/2 - 2*Space

--- a/src/c/inc_main_load_ptr.h
+++ b/src/c/inc_main_load_ptr.h
@@ -1,19 +1,20 @@
+  time_pos = time_pos_normal = time_pos_tiny = 94+Y_OFFSET; // quick view not supported there
 
   background_paint_layer = layer_create(GRect(0, 0, 180, 180));
   layer_set_update_proc(background_paint_layer, layer_update_callback_background);
   layer_add_child(main_window_layer, background_paint_layer);
   
-  s_image_layer_hour_1 = layer_create(GRect(4+X_OFFSET-5, 94+Y_OFFSET, 26, 41));
+  s_image_layer_hour_1 = layer_create(GRect(4+X_OFFSET-5, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_hour_1, layer_update_callback_hour_1);
   layer_add_child(main_window_layer, s_image_layer_hour_1);
-  s_image_layer_hour_2 = layer_create(GRect(37+X_OFFSET-5, 94+Y_OFFSET, 26, 41));
+  s_image_layer_hour_2 = layer_create(GRect(37+X_OFFSET-5, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_hour_2, layer_update_callback_hour_2);
   layer_add_child(main_window_layer, s_image_layer_hour_2);
   
-  s_image_layer_minute_1 = layer_create(GRect(80+X_OFFSET-5, 94+Y_OFFSET, 26, 41));
+  s_image_layer_minute_1 = layer_create(GRect(80+X_OFFSET-5, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_minute_1, layer_update_callback_minute_1);
   layer_add_child(main_window_layer, s_image_layer_minute_1);
-  s_image_layer_minute_2 = layer_create(GRect(111+X_OFFSET-5, 94+Y_OFFSET, 26, 41));
+  s_image_layer_minute_2 = layer_create(GRect(111+X_OFFSET-5, TIME_POS(), 26, 41));
   layer_set_update_proc(s_image_layer_minute_2, layer_update_callback_minute_2);
   layer_add_child(main_window_layer, s_image_layer_minute_2);
   

--- a/wscript
+++ b/wscript
@@ -58,5 +58,5 @@ def build(ctx):
             binaries.append({'platform': p, 'app_elf': app_elf})
 
     ctx.set_group('bundle')
-    ctx.pbl_bundle(binaries=binaries, js='pebble-js-app.js' if has_js else [])
+    ctx.pbl_bundle(binaries=binaries, js_entry_file='pebble-js-app.js' if has_js else [])
     


### PR DESCRIPTION
Note: Aplite and Chalk don't support this feature. This wasn't a problem with Chalk, it just ignores the code. It was, however, an issue with Aplite, because increased code size caused OOM conditions. For this reason, the code is #ifdef-ed for Aplite.